### PR TITLE
Fix test_coverage_manifest on macos_test_runner

### DIFF
--- a/apple/testing/default_runner/macos_test_runner.template.sh
+++ b/apple/testing/default_runner/macos_test_runner.template.sh
@@ -163,9 +163,9 @@ if [[ "${COVERAGE:-}" -ne 1 ]]; then
 fi
 
 llvm_coverage_manifest="$COVERAGE_MANIFEST"
-readonly provided_llvm_coverage_manifest="%(test_llvm_coverage_manifest)s"
-if [[ -s "${provided_llvm_coverage_manifest:-}" ]]; then
-  llvm_coverage_manifest="$provided_llvm_coverage_manifest"
+readonly provided_coverage_manifest="%(test_coverage_manifest)s"
+if [[ -s "${provided_coverage_manifest:-}" ]]; then
+  llvm_coverage_manifest="$provided_coverage_manifest"
 fi
 
 readonly profdata="$TEST_TMP_DIR/coverage.profdata"


### PR DESCRIPTION
The `macos_test_runner` was looking for a `test_llvm_coverage_manifest` env var, but it's named `test_coverage_manifest`.

Looked at the iOS test runner implementation as a reference (which works for me).